### PR TITLE
Use sh instead of shell-session so that hashes aren't missed in ctrl-C

### DIFF
--- a/docs/source/Installation.rst
+++ b/docs/source/Installation.rst
@@ -10,7 +10,7 @@ Conda
 
 A quick method is via `conda`:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   # Create a new environment for UShER
   conda create -n usher-env
@@ -27,7 +27,7 @@ A quick method is via `conda`:
 Conda Local Build
 ---------------------
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   git clone https://github.com/yatisht/usher.git
   cd usher/install
@@ -46,7 +46,7 @@ Conda Local Build
 
 followed by, if on a MacOS system:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   rsync -aP rsync://hgdownload.soe.ucsc.edu/genome/admin/exe/macOSX.x86_64/faToVcf .
   chmod +x faToVcf
@@ -55,7 +55,7 @@ followed by, if on a MacOS system:
 
 or if on a Linux system:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   rsync -aP rsync://hgdownload.soe.ucsc.edu/genome/admin/exe/linux.x86_64/faToVcf . 
   chmod +x faToVcf
@@ -64,7 +64,7 @@ or if on a Linux system:
 Executables will be located in the build and scripts directories. Make sure they're on your path for your system as appropriate, 
 or that you modify your commands to indicate their location.
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   export PATH=$PATH:/path/to/install/usher/build/
   export PATH=$PATH:/path/to/install/usher/scripts/
@@ -74,14 +74,14 @@ Docker
 
 From DockerHub:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   docker pull yatisht/usher:latest
   docker run -t -i yatisht/usher:latest /bin/bash
   
 OR locally:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
    git clone https://github.com/yatisht/usher.git
    cd usher
@@ -93,25 +93,25 @@ OR locally:
 Installation scripts
 ------------------------
 
-.. code-block:: shell-session
+.. code-block:: sh
   
   git clone https://github.com/yatisht/usher.git
   cd usher
   
 For MacOS 10.14 or above:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   ./install/installMacOS.sh
 
 For Ubuntu 18.04 and above (requires sudo privileges):
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   ./install/installUbuntu.sh
 
 For CentOS 7 and above (requires sudo privileges):
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   ./install/installCentOS.sh

--- a/docs/source/QuickStart.rst
+++ b/docs/source/QuickStart.rst
@@ -10,7 +10,7 @@ Quick install
 
 To quickly install the UShER package, use the following conda instructions:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   # Create a new environment for UShER
   conda create -n usher-env
@@ -29,7 +29,7 @@ UShER
 
 To get acquainted with UShER, we provide a simple example of placing 10 samples on an existing phylogeny. First, download the example files.
 
-.. code-block:: shell-session
+.. code-block:: sh
   
   wget https://raw.githubusercontent.com/yatisht/usher/master/test/global_phylo.nh
   wget https://raw.githubusercontent.com/yatisht/usher/master/test/global_samples.vcf
@@ -37,13 +37,13 @@ To get acquainted with UShER, we provide a simple example of placing 10 samples 
 
 Then, create a mutation annotated tree object:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   usher --tree global_phylo.nh --vcf global_samples.vcf --collapse-tree --save-mutation-annotated-tree global_phylo.pb
 
 Now, we want to place the samples from `missing_10.vcf.gz` onto our tree. We can do this by using the following command:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   usher --vcf new_samples.vcf --load-mutation-annotated-tree global_phylo.pb --write-uncondensed-final-tree
 
@@ -55,7 +55,7 @@ This yields the following three files:
 
 A simplified workflow to add user-specified samples in .fasta format to the latest public MAT is available using the following commands:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   cd usher/workflows
   snakemake --use-conda --cores 4 --config FASTA="/path/to/fasta" RUNTYPE="usher"
@@ -67,20 +67,20 @@ matUtils
 matUtils is a toolkit for rapid exploratory analysis and manipulation of mutation-annotated trees (MATs).
 The full manual page including detailed parameter information can be found `here <https://usher-wiki.readthedocs.io/en/latest/matUtils.html>`_. matUtils is installed with the UShER package (see above installation instructions using conda).
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   wget https://hgwdev.gi.ucsc.edu/~angie/UShER_SARS-CoV-2/2021/05/17/public-2021-05-17.all.masked.nextclade.pangolin.pb.gz
 
 matUtils can quickly survey the contents of MAT files with `matUtils summary`.
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   matUtils summary -i public-2021-05-17.all.masked.nextclade.pangolin.pb.gz
 
 matUtils is capable of quickly filtering on a variety of conditions and generating a series of outputs with a single call to `matUtils extract`.
 These outputs include newick, vcf, other pb, and Augur JSON capable of being visualized on the `Auspice <https://auspice.us/>`_ web platform.
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   matUtils extract -i public-2021-05-17.all.masked.nextclade.pangolin.pb.gz -a 3 -b 10 -k "Scotland/QEUH-13C22D1/2021|21-03-10:100" -v my_subset.vcf -t my_subset.newick -j my_subset.json
 
@@ -98,7 +98,7 @@ matOptimize
 matOptimize is a program that can optimize the topology of mutation-annotated trees (MATs) using subtree pruning and regrating (SPR) moves for parsimony.
 The full manual page including detailed parameter information can be found `here <https://usher-wiki.readthedocs.io/en/latest/matOptimize.html>`_. matOptimize is installed with the UShER package (see above installation instructions using conda).
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   wget http://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2/2021/05/25/public-2021-05-25.all.masked.pb.gz
   # matOptimize. does not support compressed files
@@ -113,7 +113,7 @@ RIPPLES
 
 RIPPLES is a program that can detect recombinant nodes and their ancestors in a mutation-annotated tree (MAT). The full manual page including detailed parameter information can be found `here <https://usher-wiki.readthedocs.io/en/latest/ripples.html>`_. RIPPLES is installed with the UShER package (see above installation instructions using conda).
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   wget http://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2/2021/05/25/public-2021-05-25.all.masked.pb.gz
   ripples -i public-2021-05-25.all.masked.pb.gz -T 32 -d recomb_dir/

--- a/docs/source/Strain_Phylogenetics.rst
+++ b/docs/source/Strain_Phylogenetics.rst
@@ -12,7 +12,7 @@ RotTrees enables quick inference of congruence of tanglegrams. This is particula
 
 First, ensure that `tree_1.nh` and `tree_2.nh` have identical sets of samples. Then, use as follows:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   ./build/rotate_trees --T1 tree_1.nh --T2 tree_2.nh --T1_out rot-tree_1.nh --T2_out rot-tree_2.nh
 
@@ -31,7 +31,7 @@ Below is a GIF of approximately 20 frames showing various operations of the tree
 Options
 ------------
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   --T1: Input tree 1 (in Newick format).  
   --T2: Input tree 2 (in Newick format).  
@@ -44,7 +44,7 @@ Options
 TreeMerge
 ----------
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   python3 scripts/tree_merge.py -T1 tree_1.nh -T2 tree_2.nh -symmetric 1 -T_out symm-merged-tree_1-tree_2.nh
 
@@ -58,7 +58,7 @@ The above command produces a merged tree (`symm-merged-tree_1-tree_2.nh`) from t
 Options
 ------------
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   -T1: tree 1 (in Newick format). (REQUIRED)  
   -T2: tree 2 (in Newick format). (REQUIRED)  
@@ -71,13 +71,13 @@ Options
 Find parsimonious assignments
 -----------------------------------
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   ./build/find_parsimonious_assignments --tree tree/pruned-sumtree-for-cog.nh --vcf vcf/tree_1.vcf > tree_1_PARSIMONY.txt
 
 The above command reads the tree topology of the input Newick file and assigns an internal numeric label for each internal node (ignoring the internal labels and branch lengths if already provided by the input Newick). The first two lines of the output file print the input tree with internal nodes labelled in Newick format. The output is too large to display, so we view the first 1000 characters using the command below.
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   head -c 1000 tree_1_PARSIMONY.txt  
 
@@ -86,7 +86,7 @@ For each variant/site in the VCF file, the output file then displays the allele 
 Options
 ------------
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   --tree: Input tree file.
   --vcf: Input VCF file (in uncompressed or gzip-compressed format).
@@ -98,13 +98,13 @@ Options
 Identify extremal sites
 ----------------------------------------
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   python3 scripts/identify_extremal_sites.py -in tree_1_PARSIMONY.txt
 
 The above command can be used for identifying and flagging extremal sites i.e. sites having exceptional parsimony scores relative to their allele frequencies and therefore also suspected to contain systematic errors. The above command identifies 6 extremal sites (C11074T, C27046T, T13402G, A3778G, G24390C, G26144T) with a phylogenetic instability value of 3.03. For the precise definition of extremal sites and phylogenetic instability, refer to our manuscript referenced at the bottom. The code also provides an ability to ignore high-frequency C\>T and G\>T mutations using optional flags.
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   python3 scripts/identify_extremal_sites.py -in tree_1_PARSIMONY.txt -ignoreCtoT=1 -ignoreGtoT=1
 
@@ -113,7 +113,7 @@ The above command identifies three extremal sites (T13402G, A3778G, G24390C) wit
 Options
 ------------
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   -in: Input parsimony file.  
   -ignoreCtoT: Set to 1 to ignore C>T sites (default=0)  
@@ -124,13 +124,13 @@ Options
 Plot extremal sites
 ----------------------------------------
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   python3 scripts/generate_plot_extremal_sites_data.py -in tree_1_PARSIMONY.txt > plot_extremal_sites_data.txt
 
 The above commands create raw input data for the extremal sites plot.
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   Rscript --vanilla scripts/plot_parsimony.r plot_extremal_sites_data.txt extremal_sites_plot.pdf
 

--- a/docs/source/UShER.rst
+++ b/docs/source/UShER.rst
@@ -42,7 +42,7 @@ At the end of the placement phase, UShER allows the user to create another proto
 Options
 --------------
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   --vcf (-v): Input VCF file (in uncompressed or gzip-compressed .gz format). (REQUIRED)  
   --tree (-t): Input tree file.  
@@ -71,7 +71,7 @@ Display help message
 
 To familiarize with the different command-line options of UShER, it would be useful to view its help message using the command below:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   usher --help
 
@@ -81,7 +81,7 @@ Pre-processing global phylogeny
 
 The following example command pre-processes the existing phylogeny (`global_phylo.nh`) and using the genotypes (`global_samples.vcf`) and generates the mutation-annotated tree object that gets stored in a protobuf file (`global_assignments.pb`). Note that UShER would automatically place onto the input global phylogeny any samples in the VCF (to convert a fasta sequence to VCF, consider using Fasta2USHER that are missing in the input global phylogeny using its parsimony-optimal placement algorithm. This final tree is written to a file named `final-tree.nh` in the folder specified by `--outdir` or `-d` option (if not specified, default uses current directory). 
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   usher -t test/global_phylo.nh -v test/global_samples.vcf -o global_assignments.pb -d output/
 
@@ -89,13 +89,13 @@ By default, UShER uses **all available threads** but the user can also specify t
 
 UShER also allows an option during the pre-processing phase to collapse nodes (i.e. delete the node after moving its child nodes to its parent node) that are not inferred to contain a mutation through the Fitch-Sankoff algorithm as well as to condense nodes that contain identical sequences into a single representative node. This is the **recommended usage** for UShER as it not only helps in significantly reducing the search space for the placement phase but also helps reduce ambiguities in the placement step and can be done by setting the `--collapse-tree` or `-c` parameter. The collapsed input tree is stored as `condensed-tree.nh` in the output directory. 
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   usher -t test/global_phylo.nh -v test/global_samples.vcf -o global_assignments.pb -c -d output/
 
 Note the the above command would condense identical sequences, namely S2, S3 and S4, in the example figure above into a single condensed new node (named something like *node_1_condensed_3_leaves*). If you wish to display the collapsed tree without condensing the nodes, also set the `--write-uncondensed-final-tree` or `-u` option, for example, as follows:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   usher -t test/global_phylo.nh -v test/global_samples.vcf -o global_assignments.pb -c -u -d output/
 
@@ -106,7 +106,7 @@ Placing new samples
 
 Once the pre-processing is complete and a mutation-annotated tree object is generate (e.g. `global_assignments.pb`), UShER can place new sequences whose variants are called in a VCF file (e.g. `new_samples.vcf`) to existing tree as follows:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   usher -i global_assignments.pb -v test/new_samples.vcf -u -d output/
 
@@ -116,7 +116,7 @@ The above command not only places each new sample sequentially, but also reports
 
 In addition to the global phylogeny, one often needs to contextualize the newly added sequences using subtrees of closest *N* neighbouring sequences, where *N* is small. UShER allows this functionality using `--write-subtrees-size` or `-k` option, which can be set to an arbitrary *N*, such as 20 in the example below:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   usher -i global_assignments.pb -v test/new_samples.vcf -u -k 20 -d output/
 
@@ -124,7 +124,7 @@ The above command writes subtrees to files names `subtree-<subtree-number>.nh`. 
 
 Finally, the new mutation-annotated tree object can be stored again using `--save-mutation-annotated-tree` or `-o` option (overwriting the loaded protobuf file is allowed).
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   usher -i global_assignments.pb -v test/new_samples.vcf -u -o new_global_assignments.pb -d output/
 
@@ -139,7 +139,7 @@ Branch Parsimony Score
 
 UShER also allows quantifying the uncertainty in placing new samples by reporting the parsimony scores of adding new samples to all possible nodes in the tree **without** actually modifying the tree (this is because the tree structure, as well as number of possible optimal placements could change with each new sequential placement). In particular, this can help the user explore which nodes of the tree result in a small and optimal or near-optimal parsimony score. This can be done by setting the `--write-parsimony-scores-per-node` or `-p` option, for example, as follows:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   usher -i global_assignments.pb -v test/new_samples.vcf -p -d output/ 
 
@@ -157,13 +157,13 @@ Multiple parsimony-optimal placements
 
 To further aid the user to quantify phylogenetic uncertainty in placement, UShER has an ability to enumerate all possible topologies resulting from equally parsimonious sample placements. UShER does this by maintaining a list of mutation-annotated trees (starting with a single mutation-annotated tree corresponding to the input tree of existing samples) and sequentially adds new samples to each tree in the list while increasing the size of the list as needed to accommodate multiple equally parsimonious placements for a new sample. This feature is available using the `--multiple-placements` or `-M` option in which the user specifies the maximum number of topologies that UShER should maintain before it reverts back to using the default tie-breaking strategy for multiple parsimony-optimal placements in order to keep the runtime and memory usage of UShER reasonable. 
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   usher -i global_assignments.pb -v <USER_PROVIDED_VCF> -M -d output/
 
 Note that if the number of equally parsimonious placements for the initial samples is large, the tree space can get too large too quickly and slow down the placement for the subsequent samples. Therefore, UShER also provides an option to sort the samples first based on the number of equally parsimonious placements using the `-S` option. 
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   usher -i global_assignments.pb -v <USER_PROVIDED_VCF> -M -S -d output/
 
@@ -179,7 +179,7 @@ Finding sister clades
 
 To determine the accuracy of each sample placement, one might be interested in knowing all of the sister clades of that sample on the final tree. `We provide a utility for this calculation here <http://public.gi.ucsc.edu/~yatisht/data/binaries/find_sister_clades>`_. `find_sister_clades` takes the following options:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   --tree: Input tree file.  
   --samples: File containing missing samples.  
@@ -188,7 +188,7 @@ To determine the accuracy of each sample placement, one might be interested in k
 
 An example usage of this function is given below:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   find_sister_clades --generations 1 final-tree.nh --samples list-of-samples.txt > sister_clades.txt
 
@@ -211,7 +211,7 @@ Generating Multiple Sequence Alignment (MSA)
 
 Users can generate multiple sequence alignment of the input sequences using `MAFFT <https://mafft.cbrc.jp/alignment/software/>`_ that is already `installed <https://github.com/yatisht/usher#installing-usher>`_ with UShER package. For example, we provide a number of example SARs-CoV-2 sequences in `test/Fasta2UShER` that can be combined in a single fasta file called `combined.fa` and aligned together using the SARS-CoV-2 reference sequence `test/NC_045512v2.fa` as follows:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   cat ./test/Fasta2UShER/* > ./test/combined.fa
   mafft --thread 10 --auto --keeplength --addfragments ./test/combined.fa ./test/NC_045512v2.fa > ./test/myAlignedSequences.fa
@@ -223,28 +223,28 @@ Converting MSA to VCF
 
 Users can then use the tool faToVcf, which is also installed via UShER's package, to then convert the fasta file containing multiple alignment of input sequences into a VCF.  If the file `./test/myAlignedSequences.fa` includes the reference sequence (for SARS-CoV-2, `NC_045512.2 <https://www.ncbi.nlm.nih.gov/nuccore/NC_045512.2>`_) as its first sequence, then faToVcf can be run like this:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   faToVcf ./test/myAlignedSequences.fa ./test/test_merged.vcf
 
 
 If the reference sequence is included in `./test/myAlignedSequences.fa` but is not the first sequence, then its name needs to be specified using the `-ref=...` option:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   faToVcf -ref=NC_045512.2 ./test/myAlignedSequences.fa ./test/test_merged.vcf
 
 
 If the reference sequence is not included in `./test/myAlignedSequences.fa` then it can be added in the bash shell using a named pipe like this:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   faToVcf <(cat NC_045512.2.fa ./test/myAlignedSequences.fa) ./test/test_merged.vcf
 
 
 For SARS-CoV-2 data, we recommend downloading `problematic_sites_sarsCov2.vcf` and using it for masking `problematic sites <https://virological.org/t/issues-with-sars-cov-2-sequencing-data/473/14>`_ as follows:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   wget https://raw.githubusercontent.com/W-L/ProblematicSites_SARS-CoV2/master/problematic_sites_sarsCov2.vcf
   faToVcf  -maskSites=problematic_sites_sarsCov2.vcf   ./test/myAlignedSequences.fa ./test/test_merged_masked.vcf

--- a/docs/source/matOptimize.rst
+++ b/docs/source/matOptimize.rst
@@ -16,7 +16,7 @@ To install matOptimize, simply follow the directions for `installing UShER <http
 Options
 --------------
 
-.. code-block:: shell-session
+.. code-block:: sh
 
  -v [ --vcf ] arg                      Input VCF file (in uncompressed or 
                                         gzip-compressed .gz format) 

--- a/docs/source/matUtils.rst
+++ b/docs/source/matUtils.rst
@@ -40,7 +40,7 @@ matUtils Common Options
 
 All matUtils subcommands include these parameters.
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   --input-mat (-i): Input mutation-annotated tree file. (REQUIRED)
   --threads (-T): Number of threads to use when possible. Default = use all available cores.
@@ -101,23 +101,23 @@ Example Usage
 
 1. Get a tsv containing all sample names and parsimony scores.
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   matUtils summary -i input.pb --samples samples.txt
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   matUtils summary -i public-2021-06-09.all.masked.nextclade.pangolin.pb.gz --samples 06-09_samples.txt
 
 2. Write all possible summary output files to a specific directory.
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   matUtils summary -i input.pb -A -d input_summary/
 
 3. Get amino acid translations of each node in a tree
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   matUtils summary -t translate_output.tsv -i input.pb -g annotation.gtf -f reference.fasta
 
@@ -128,14 +128,14 @@ Files needed:
 
 a. `public-2021-06-09.all.masked.nextclade.pangolin.pb.gz <https://hgwdev.gi.ucsc.edu/~angie/UShER_SARS-CoV-2/2021/06/09/public-2021-06-09.all.masked.nextclade.pangolin.pb.gz>`_
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   matUtils summary -i public-2021-06-09.all.masked.nextclade.pangolin.pb.gz -A -d 06-09_summary/
 
 Specific Options
 ----------------------
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   --input-mat (-i): Input mutation-annotated tree file [REQUIRED]. If only this argument is set, print the count of samples and nodes in the tree.
   --input-gtf (-g): Input GTF annotation file. Required for --translate (-t)
@@ -175,17 +175,17 @@ Example Syntax and Usage
 
 1. Write a vcf representing all samples within a clade.
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   matUtils extract -i input.pb -c my_clade -v my_clade.vcf
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   matUtils extract -i public-2021-06-09.all.masked.nextclade.pangolin.pb.gz -c B.1.351 -v 351_samples.vcf
   
 The VCF file can be converted to a Fasta files (one for each sequence in the VCF) using vcf2fasta (see installation instructions `here <https://github.com/vcflib/vcflib#install>`_) and the reference sequence (in NC_045512v2.fa) as follows:
   
-.. code-block:: shell-session
+.. code-block:: sh
 
   vcfindex 351_samples.vcf
   vcf2fasta -f NC_045512v2.fa 351_samples.vcf
@@ -194,27 +194,27 @@ Note that indels are ignored in the above approach since they're not included in
 
 2. Write a newick tree of all samples which contain either of two mutations of interest.
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   matUtils extract -i input.pb -m my_mutation,my_other_mutation -t my_mutations.nwk
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   matUtils extract -i public-2021-06-09.all.masked.nextclade.pangolin.pb.gz -m G7328T,A8653G -t double_mutant.nwk
 
 3. Convert a MAT JSON into a .pb file, while removing branches with length greater than 7.
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   matUtils extract -i input.json -b 7 -o filtered.pb
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   matUtils extract -i usa_group.json -b 7 -o filtered_usa_group.pb
 
 4. Generate a MAT JSON representing a subtree of size 25 around a sample of interest, including multiple metadata files and filtering low-scoring samples.
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   matUtils extract -i input.pb -a 5 -M my_metadata_1.tsv,my_metadata_2.tsv -k my_sample:25 -j my_sample_context.json
 
@@ -231,7 +231,7 @@ c. :download:`region.tsv <./meta_1.tsv>`
 
 d. :download:`misc.tsv <./meta_2.tsv>`
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   matUtils extract -i public-2021-06-09.all.masked.nextclade.pangolin.pb.gz -a 5 -M meta_1.tsv,meta_2.tsv -k "Scotland/CVR6436/2020|2020-12-30:25" -j cluster.json
 
@@ -239,7 +239,7 @@ d. :download:`misc.tsv <./meta_2.tsv>`
 Specific Options
 ----------------------
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   --input-mat (-i): For this specific command, the input can either be a standard MAT protobuf or an Augur-v2-formatted MAT JSON, ala Nextstrain.
   --input-gtf (-g): Input GTF annotation file. Required for --write-taxodium.
@@ -317,7 +317,7 @@ Example Syntax and Usage
 
 1. Assign a new set of custom clade annotations to the tree.
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   matUtils annotate -i input.pb -c my_clade_info.txt -o annotated.pb
 
@@ -329,7 +329,7 @@ a. `public-2021-06-09.all.masked.pb.gz <https://hgwdev.gi.ucsc.edu/~angie/UShER_
 
 b. `cladeToPublicName.gz <https://hgwdev.gi.ucsc.edu/~angie/UShER_SARS-CoV-2/2021/06/09/cladeToPublicName.gz>`_
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   gunzip -c cladeToPublicName.gz > clade_info.txt
   matUtils annotate -i public-2021-06-09.all.masked.pb.gz -c clade_info.txt -o nxts_annotated.pb
@@ -338,7 +338,7 @@ b. `cladeToPublicName.gz <https://hgwdev.gi.ucsc.edu/~angie/UShER_SARS-CoV-2/202
 Specific Options
 ------------------
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   --output-mat (-o): Path to output processed mutation-annotated tree file (REQUIRED)
   --clade-names (-c): Path to a file containing clade asssignments of samples. An algorithm automatically locates and annotates clade root nodes.
@@ -390,7 +390,7 @@ Example Syntax and Usage
 
 1. Calculate uncertainty metrics for a specific set of samples.
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   matUtils uncertainty -i input.pb -s my_samples.txt -e my_uncertainty.tsv
 
@@ -402,7 +402,7 @@ a. `public-2021-06-09.all.masked.nextclade.pangolin.pb.gz <https://hgwdev.gi.ucs
 
 b. :download:`eng_samples.txt<./eng_samples.txt>`
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   matUtils uncertainty -i public-2021-06-09.all.masked.nextclade.pangolin.pb.gz -s eng_samples.txt -e eng_uncertainty.tsv
 
@@ -410,7 +410,7 @@ b. :download:`eng_samples.txt<./eng_samples.txt>`
 Options
 -----------
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   --samples (-s): File containing samples to calculate metrics for.
   --find-epps (-e): Writes an Auspice-compatible two-column tsv of the number of equally parsimonious placements and neighborhood sizes for each sample to the target file. 
@@ -503,7 +503,7 @@ Example Syntax and Usage
 
 1. Generate a tsv containing inferred introduction information, one sample per row.
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   matUtils introduce -i public.pb -s my_region_samples.txt -o my_region_introductions.tsv
   
@@ -515,7 +515,7 @@ a. `public-2021-06-09.all.masked.nextclade.pangolin.pb.gz <https://hgwdev.gi.ucs
 
 b. :download:`regional-samples.txt <./regional-samples.txt>`
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   matUtils introduce -i public-2021-06-09.all.masked.nextclade.pangolin.pb.gz -s regional-samples.txt -o regional-introductions.tsv
 
@@ -523,7 +523,7 @@ b. :download:`regional-samples.txt <./regional-samples.txt>`
 Options
 -----------
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   --population-samples (-s): Two-column tab-separated text file containing sample names and region membership respectively (REQUIRED)
   --output (-o): Name of the output tab-separated table containing inferred introductions, one sample per row (REQUIRED)

--- a/docs/source/ripples.rst
+++ b/docs/source/ripples.rst
@@ -30,7 +30,7 @@ In the partial phylogeny shown above, node **f** is the result of a recombinatio
 Options
 --------------
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   --input-mat (-i): Input mutation-annotated tree file [REQUIRED]. If only this argument is set, print the count of samples and nodes in the tree.
   --outdir (-d): Write all output files to the target directory. Default is current directory.

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -16,7 +16,7 @@ Users interested in recombination may want to use RIPPLES to search for recombin
 
 First, download the latest public tree, a set of sample sequences to search for recombination, the reference genome, and sites to mask:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
     wget http://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2/public-latest.all.masked.pb.gz
     wget https://raw.githubusercontent.com/bpt26/usher_wiki/main/docs/source/test_samples.fa
@@ -26,14 +26,14 @@ First, download the latest public tree, a set of sample sequences to search for 
 .. note:: 
     Your exact results may be slightly different than what is shown here, as the public tree is updated daily. To get the same tree used in this tutorial, use the following command:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   wget http://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2/2021/08/04/public-2021-08-04.all.masked.pb
 
 
 Then, mask problematic sites using the downloaded .vcf:
 
-.. code-block:: shell-session
+.. code-block:: sh
     
     gunzip wuhCor1.fa.gz
     mafft --thread 10 --auto --keeplength --addfragments test_samples.fa wuhCor1.fa > aligned_seqs.fa
@@ -41,13 +41,13 @@ Then, mask problematic sites using the downloaded .vcf:
 
 Then, use UShER to add your samples to the protobuf:
 
-.. code-block:: shell-session
+.. code-block:: sh
     
     usher -T 10 -i public-latest.all.masked.pb.gz -v aligned_seqs.vcf -o user_seqs.pb
 
 Then, use RIPPLES to search for recobination events involving these samples in the tree:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
     mkdir USER_SAMPLES/
     grep -e '>' test_samples.fa | perl -pi -e 's/>//' > user_samples.txt
@@ -55,13 +55,13 @@ Then, use RIPPLES to search for recobination events involving these samples in t
 
 After a few minutes, RIPPLES produces files `recombination.tsv` and `descendants.tsv`. The last two columns in the `recombination.tsv` file represent the parsimony score improvement. Suppose that we are interested specifically in recombinant nodes with highest parsimony score improvement, as these are more likely to reflect true recombination events. This command yields all recombination events with parsimony improvements greater than 7:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
     awk '$11 - $12 > 7' USER_SAMPLES/recombination.tsv
 
 The results should look something like this:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
     node_49072  (0,241) (10870,11288) node_111282 n 41  node_49068  n 12  12  12  4
     node_49072  (0,241) (14408,14676) node_179776 n 36  node_49068  n 12  12  12  4
@@ -87,7 +87,7 @@ The results should look something like this:
 
 We can then parse the `descendants.tsv` file to look at the descendants for each of these nodes:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
     awk '$1 == "node_49072"' USER_SAMPLES/descendants.tsv
     awk '$1 == "node_92879"' USER_SAMPLES/descendants.tsv
@@ -101,7 +101,7 @@ Snakemake Workflow
 
 Alternatively, after `installing snakemake <https://snakemake.readthedocs.io/en/stable/getting_started/installation.html>`_, the following set of commands may be used to search for evidence of recombination in a user-input set of sequences:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
     cd usher/workflows
     snakemake --use-conda --cores 4 --config FASTA="/path/to/fasta" RUNTYPE="ripples"
@@ -120,7 +120,7 @@ We recommend using `Cov2Tree <https://cov2tree.org/>`_ develoepd by `Theo Sander
 
 To accommodate this, we include the -l option in matUtils extract to produce a MAT in a format that is readable by Taxodium. 
 
-.. code-block:: shell-session
+.. code-block:: sh
 
     wget https://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/bigZips/wuhCor1.fa.gz && gunzip wuhCor1.fa.gz
     wget http://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/bigZips/genes/ncbiGenes.gtf.gz && gunzip ncbiGenes.gtf.gz
@@ -133,7 +133,7 @@ Snakemake Workflow
 
 For simplicity, we include the above set of commands as a `snakemake <https://snakemake.readthedocs.io/en/stable/getting_started/installation.html>`_ workflow. Here, the user-specified input is a set of sequences to be added to the latest public tree. This workflow can be run using the following commands:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
     cd usher/workflows
     snakemake --use-conda --cores 4 --config FASTA=”path/to/fa/file” RUNTYPE=”taxodium”
@@ -150,34 +150,34 @@ or an Augur-formatted MAT JSON file as used by Nextstrain. matUtils can be used 
 few other tools can manage efficiently.
 The first step to using one of these public files is `matUtils summary`, which can calculate basic statistics or summarize sample, clade, or mutation-level frequency information.
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   matUtils summary -i public-2021-05-17.all.masked.nextclade.pangolin.pb.gz 
 
 This particular tree has 757500 unique samples represented in it. We can further explore this dataset with another `matUtils summary` command:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   matUtils summary -i public-2021-05-17.all.masked.nextclade.pangolin.pb.gz -A -d summary_out
 
 Let's say we're interested in recurrent, or homoplasic, mutations across this tree. The mutations summary file contains the number of independent occurrences of a 
 mutation across the tree. 
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   awk '$2 >= 500' summary_out/mutations.tsv
 
 C>T mutations are very overrepresented in this set, being a common mutation and error type. We're concerned about correctly identifying real homoplasic mutations,
 instead of coincident or erroneous mutations, so we filter the dataset down to higher-quality placements and samples.
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   matUtils extract -i public-2021-05-17.all.masked.nextclade.pangolin.pb.gz -a 3 -b 5 -o filtered.pb
   matUtils summary -i filtered.pb
 
 After filtering, our tree contains 701375 samples, which is 92% of the original tree size. Let's see how our homoplasic mutation output looks.
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   matUtils summary -i filtered.pb -m filtered_mutations.tsv
   awk '$2 > 500' filtered_mutations.tsv
@@ -191,7 +191,7 @@ If we were interested in following up on this potential homoplasy, we have a few
 samples with this specific mutation, along with a JSON for visualization and additional sample path information. We can perform all these operations with
 a single command.
 
-.. code-block:: shell-session
+.. code-block:: sh
 
   matUtils extract -i filtered.pb -m G7328T -o G7328T.pb -j G7328T.json -S G7328T_sample_paths.txt 
 
@@ -209,7 +209,7 @@ Snakemake Workflow
 
 We also provide a `snakemake <https://snakemake.readthedocs.io/en/stable/getting_started/installation.html>`_ workflow to add user-input sequences in .fasta format to the latest public tree, and extract subtrees of size 500 for each. These subtrees are output in .json format for simple drag-and-drop visualization with `Auspice <https://auspice.us/>`_. This workflow can be run using the following commands:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
     cd usher/workflows
     snakemake --use-conda --cores 4 --config FASTA=”path/to/fa/file” RUNTYPE=”matUtils”
@@ -226,21 +226,21 @@ Download the example protobuf file `public-2021-05-17.all.masked.nextclade.pango
 The first step is generating a visualizable JSON of the clade of interest, along with getting the names of samples involved.
 This is done with matUtils extract. In our example, we will get the samples associated with a small pangolin clade.
 
-.. code-block:: shell-session
+.. code-block:: sh
 
     matUtils extract -i public-2021-05-17.all.masked.nextclade.pangolin.pb.gz -c B.1.500 -u b1500_samples.txt -j b1500_viz.json
 
 The second step is to call matUtils uncertainty. The input PB is the original PB, with the sample selection text file, instead of a subtree pb generated with -o.
 This is because its going to search for placements all along the original tree; if a subtree .pb was passed, it would only search for placements within that subtree.
 
-.. code-block:: shell-session
+.. code-block:: sh
 
     matUtils uncertainty -i public-2021-05-17.all.masked.nextclade.pangolin.pb.gz -s b1500_samples.txt -e b1500_uncertainty.tsv -o b1500_placements.tsv
 
 These can now be uploaded for visualization by drag and drop onto the `auspice <https://auspice.us/>`_ website. Drag and drop the b1500_viz.json first, then the tsv files second.
 Alternatively, one of the metadata files can be included in JSON generation by matUtils extract.
 
-.. code-block:: shell-session
+.. code-block:: sh
 
     matUtils extract -i public-2021-05-17.all.masked.nextclade.pangolin.pb.gz -s b1500_placements.txt -z 100 -M b1500_placements.tsv -j b1500_annotated.json
 
@@ -267,14 +267,14 @@ Before beginning, download the example protobuf file `public-2021-04-20.all.mask
 We need a region to analyze; in this example, we are going to use Spain, as it has a few hundred associated samples in the public data
 and is a solid representative example. We need to generate the two-column tab-separated file we use as input to `matUtils introduce`.
 
-.. code-block:: shell-session
+.. code-block:: sh
 
     matUtils summary -i public-2021-04-20.all.masked.nextclade.pangolin.pb -s 420_sample_parsimony.txt
     grep “Spain” 420_sample_parsimony.txt | awk ‘{print $1”\tSpain”}’ > spanish_samples.txt
 
 We can now apply `matUtils introduce` using this file as input.
 
-.. code-block:: shell-session
+.. code-block:: sh
 
     matUtils introduce -i public-2021-04-20.all.masked.nextclade.pangolin.pb -s spanish_samples.txt -o spanish_introductions.txt
 
@@ -287,7 +287,7 @@ marking the point on the history where we stop being confident that the represen
 
 We can count the number of unique introductions into our region of interest- in this case Spain- using awk.
 
-.. code-block:: shell-session
+.. code-block:: sh
 
     awk '{print $2}' spanish_introductions.tsv | sort | uniq -c | sort -r | head -25 
 
@@ -299,7 +299,7 @@ new regional clades are sampled only once or not at all.
 There are some interesting cases of clades from a single introduction, however. The clade introduced at the internal node "96055" 
 contains 9 closely related samples from Spain and are all members of the variant of concern B.1.1.7.
 
-.. code-block:: shell-session
+.. code-block:: sh
 
     awk '$2 == "96055"' spanish_introductions.tsv
 
@@ -309,7 +309,7 @@ contains 9 closely related samples from Spain and are all members of the variant
 
 The first entry of this output is reproduced here, sans the mutation path.
 
-.. code-block:: shell-session
+.. code-block:: sh
 
     ESP/hCoV-19_Spain_CT-HUVH-32938_2021/2021|MW769763.1|21-01-14	96055	2	4.5	2021-Jan-14	2021-Jan-21	9	51		1	0.0431655	3
 
@@ -321,7 +321,7 @@ growth score of 9/(1+1) or 4.5, which puts it second on our ranked cluster list.
 To do this, first we will need to generate an auspice-compatible JSON containing our introduction set and some context samples. We can do this 
 by selecting one of our samples and extracting the context to a JSON with `matUtils extract`.
 
-.. code-block:: shell-session
+.. code-block:: sh
 
     matUtils extract -i public-2021-04-20.all.masked.nextclade.pangolin.pb -k "ESP/hCoV-19_Spain_CT-HUVH-76622_2021/2021|MW769758.1|21-01-19:50" -j spanish_introduction.json
 
@@ -355,7 +355,7 @@ Snakemake Workflow
 
 We also provide a `snakemake <https://snakemake.readthedocs.io/en/stable/getting_started/installation.html>`_ workflow to search for unique introductions within a user-input set of samples. This workflow can be run using the following commands:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
     cd usher/workflows
     snakemake --use-conda --cores 4 --config FASTA="/path/to/fasta" RUNTYPE="introduce"
@@ -375,13 +375,13 @@ The output table of summary is by-occurrence, so distributions of values associa
 
 Before beginning, download the example protobuf file `public-2021-06-09.all.masked.nextclade.pangolin.pb.gz <http://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2//2021/06/09/public-2021-06-09.all.masked.nextclade.pangolin.pb.gz>`_ 
 
-.. code-block:: shell-session
+.. code-block:: sh
 
     matUtils summary -i public-2021-06-09.all.masked.nextclade.pangolin.pb.gz -R roho_scores.tsv
 
 The resulting table contains the following columns:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
     mutation	parent_node	child_count	occurrence_node	offspring_with	median_offspring_without	single_roho
 
@@ -443,7 +443,7 @@ The example protobuf file is a simple tree with the following structure:
 
 To call amino acid mutations in the mutation-annotated tree, run the following commmand:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
     matUtils summary --translate coding_mutations.tsv -i translate_example.pb -g ncbiGenes.gtf -f NC_045512v2.fa
     
@@ -532,7 +532,7 @@ Snakemake Workflow
 
 We also include a `snakemake <https://snakemake.readthedocs.io/en/stable/getting_started/installation.html>`_ workflow to translate mutations in a user-input .fasta file to amino acid substitutions in a lineage-aware manner. This workflow can be run using the following commands:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
     cd usher/workflows
     snakemake --use-conda --cores 4 --config FASTA="/path/to/fa" RUNTYPE="translate"
@@ -548,7 +548,7 @@ The instructions here can be applied to a number of additional languages support
 
 The first step is to call the protoc compiler to retrieve a MAT protobuf parser. Navigate to your Usher installation (or clone the github if you installed via conda) and call:
 
-.. code-block:: shell-session
+.. code-block:: sh
 
     protoc -I=./ --python_out=./ ./parsimony.proto
 


### PR DESCRIPTION
Something that sometimes throws me, and might confuse new users is that when you try to copy snippets from the (excellent) UShER docs, you get something like this:

![image](https://user-images.githubusercontent.com/19732295/166473017-6a960d17-fb62-4baf-9115-81595cbe8a54.png)

The `#`s indicating comments are not selected, and not copied and so if you naively paste this the terminal tries to execute the comments.

This PR ([demo](https://usher-wiki-test-theo.readthedocs.io/en/latest/QuickStart.html#quick-install)) would change the code blocks to use `sh` not `shell-session` which seems to avoid that. 

![image](https://user-images.githubusercontent.com/19732295/166473584-26914208-10cd-4883-9eaa-7552d5c22eb0.png)

No worries if you don't like it though!