### PR TITLE
Update Tutorial to use Taxoniumtools

### DIFF
--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -128,6 +128,9 @@ You can use `Taxoniumtools <https://docs.taxonium.org/en/latest/taxoniumtools.ht
     wget http://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2/public-latest.all.masked.pb.gz
     wget https://raw.githubusercontent.com/theosanderson/taxonium/master/taxoniumtools/test_data/hu1.gb
     usher_to_taxonium --input public-latest.all.masked.pb.gz --output public-latest-taxonium.jsonl.gz --metadata public-latest.metadata.tsv --genbank hu1.gb --columns genbank_accession,country,date,pangolin_lineage
+    
+You then open that `.jsonl.gz` file on `Taxonium <https://taxonium.org>` directly, or with the `Taxonium desktop app <https://docs.taxonium.org/en/latest/app.html>` which may handle large trees better
+
 
 -----------------------------------------------------------
 Snakemake Workflow

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -112,7 +112,7 @@ Alternatively, after `installing snakemake <https://snakemake.readthedocs.io/en/
 Using Taxonium to visualize phylogenies
 -------------------------------------------------
 
-We recommend using `Taxonium <https://taxonium.org/>`_ develoepd by `Theo Sanderson <https://github.com/theosanderson/taxonium>`_ to visualize these trees. An example of a phylogeny visualized by this software is shown below:
+We recommend using `Taxonium <https://taxonium.org/>` to visualize these trees. An example of a phylogeny visualized by this software is shown below:
 
 .. image:: taxodium.jpeg
     :width: 700px

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -109,23 +109,24 @@ Alternatively, after `installing snakemake <https://snakemake.readthedocs.io/en/
 
 .. _taxodium-tutorial:
 
-Using Taxodium to visualize phylogenies
+Using Taxonium to visualize phylogenies
 -------------------------------------------------
 
-We recommend using `Cov2Tree <https://cov2tree.org/>`_ develoepd by `Theo Sanderson <https://github.com/theosanderson/taxodium>`_ to visualize these trees. An example of a phylogeny visualized by this software is shown below:
+We recommend using `Taxonium <https://taxonium.org/>`_ develoepd by `Theo Sanderson <https://github.com/theosanderson/taxonium>`_ to visualize these trees. An example of a phylogeny visualized by this software is shown below:
 
 .. image:: taxodium.jpeg
     :width: 700px
     :align: center
 
-To accommodate this, we include the -l option in matUtils extract to produce a MAT in a format that is readable by Taxodium. 
+You can use `Taxoniumtools <https://docs.taxonium.org/en/latest/taxoniumtools.html>` to convert from UShER to Taxonium format.
 
 .. code-block:: sh
 
-    wget https://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/bigZips/wuhCor1.fa.gz && gunzip wuhCor1.fa.gz
-    wget http://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/bigZips/genes/ncbiGenes.gtf.gz && gunzip ncbiGenes.gtf.gz
+    pip install taxoniumtools
     wget http://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2/public-latest.metadata.tsv.gz && gunzip public-latest.metadata.tsv.gz
-    matUtils extract -i input.pb -l output.taxodium.pb -g ncbiGenes.gtf -f wuhCor1.fa -M public-latest.metadata.tsv
+    wget http://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2/public-latest.all.masked.pb.gz  && gunzip public-latest.all.masked.pb.gz
+    wget https://raw.githubusercontent.com/theosanderson/taxonium/master/taxoniumtools/test_data/hu1.gb
+    taxoniumtools --input public-latest.all.masked.pb --output public-latest-taxonium.jsonl.gz --metadata public-latest.metadata.tsv.gz --genbank hu1.gb --columns genbank_accession,country,date,pangolin_lineage
 
 -----------------------------------------------------------
 Snakemake Workflow

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -126,7 +126,7 @@ You can use `Taxoniumtools <https://docs.taxonium.org/en/latest/taxoniumtools.ht
     wget http://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2/public-latest.metadata.tsv.gz && gunzip public-latest.metadata.tsv.gz
     wget http://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2/public-latest.all.masked.pb.gz  && gunzip public-latest.all.masked.pb.gz
     wget https://raw.githubusercontent.com/theosanderson/taxonium/master/taxoniumtools/test_data/hu1.gb
-    taxoniumtools --input public-latest.all.masked.pb --output public-latest-taxonium.jsonl.gz --metadata public-latest.metadata.tsv.gz --genbank hu1.gb --columns genbank_accession,country,date,pangolin_lineage
+    usher_to_taxonium --input public-latest.all.masked.pb --output public-latest-taxonium.jsonl.gz --metadata public-latest.metadata.tsv.gz --genbank hu1.gb --columns genbank_accession,country,date,pangolin_lineage
 
 -----------------------------------------------------------
 Snakemake Workflow

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -122,6 +122,7 @@ You can use `Taxoniumtools <https://docs.taxonium.org/en/latest/taxoniumtools.ht
 
 .. code-block:: sh
 
+    conda install -c conda-forge python
     pip install taxoniumtools
     wget http://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2/public-latest.metadata.tsv.gz && gunzip public-latest.metadata.tsv.gz
     wget http://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2/public-latest.all.masked.pb.gz  && gunzip public-latest.all.masked.pb.gz

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -125,9 +125,9 @@ You can use `Taxoniumtools <https://docs.taxonium.org/en/latest/taxoniumtools.ht
     conda install -c conda-forge python
     pip install taxoniumtools
     wget http://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2/public-latest.metadata.tsv.gz && gunzip public-latest.metadata.tsv.gz
-    wget http://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2/public-latest.all.masked.pb.gz  && gunzip public-latest.all.masked.pb.gz
+    wget http://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2/public-latest.all.masked.pb.gz
     wget https://raw.githubusercontent.com/theosanderson/taxonium/master/taxoniumtools/test_data/hu1.gb
-    usher_to_taxonium --input public-latest.all.masked.pb --output public-latest-taxonium.jsonl.gz --metadata public-latest.metadata.tsv --genbank hu1.gb --columns genbank_accession,country,date,pangolin_lineage
+    usher_to_taxonium --input public-latest.all.masked.pb.gz --output public-latest-taxonium.jsonl.gz --metadata public-latest.metadata.tsv --genbank hu1.gb --columns genbank_accession,country,date,pangolin_lineage
 
 -----------------------------------------------------------
 Snakemake Workflow

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -127,7 +127,7 @@ You can use `Taxoniumtools <https://docs.taxonium.org/en/latest/taxoniumtools.ht
     wget http://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2/public-latest.metadata.tsv.gz && gunzip public-latest.metadata.tsv.gz
     wget http://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2/public-latest.all.masked.pb.gz  && gunzip public-latest.all.masked.pb.gz
     wget https://raw.githubusercontent.com/theosanderson/taxonium/master/taxoniumtools/test_data/hu1.gb
-    usher_to_taxonium --input public-latest.all.masked.pb --output public-latest-taxonium.jsonl.gz --metadata public-latest.metadata.tsv.gz --genbank hu1.gb --columns genbank_accession,country,date,pangolin_lineage
+    usher_to_taxonium --input public-latest.all.masked.pb --output public-latest-taxonium.jsonl.gz --metadata public-latest.metadata.tsv --genbank hu1.gb --columns genbank_accession,country,date,pangolin_lineage
 
 -----------------------------------------------------------
 Snakemake Workflow


### PR DESCRIPTION
This was prompted by [this nice blog](https://omicx.cc/posts/2022-11-22-create-phylogenetic-tree-of-sars-cov-2-by-usher/) which reads:

| Although the UShER wiki recommends matUtils extract to produce a MAT for Taxonium visualization, Taxonium recommends taxoniumtools to do this conversion for current Taxonium Version 2.

It's probably easiest for new users to be pointed to Taxoniumtools (even though it's not at all perfect compared to matUtils extract in the V1 days!)