### PR TITLE
Link to global trees in the usher wiki

### DIFF
--- a/docs/source/global_trees.rst
+++ b/docs/source/global_trees.rst
@@ -8,17 +8,19 @@ SARS-CoV-2 is the virus that causes COVID-19. The global SARS-CoV-2 tree include
 
 hMPXV (Mpox)
 ------------
-Mpox, `previously known as monkeypox <https://www.who.int/news/item/28-11-2022-who-recommends-new-name-for-monkeypox-disease>`_, made news due to an outbreak in 2022. However, the disease is older than that, and the global MPXV tree includes INSDC hMPXV (human mpox virus) samples dating back to 2016 `The hMPXV trees can be found here <https://hgdownload.gi.ucsc.edu/hubs/GCF/014/621/545/GCF_014621545.1/UShER_hMPXV/>`_.
+Mpox, `previously known as monkeypox <https://www.who.int/news/item/28-11-2022-who-recommends-new-name-for-monkeypox-disease>`_, made news due to an outbreak in 2022. However, the disease is older than that, and the global MPXV tree includes INSDC hMPXV (human mpox virus) samples dating back to 2016. `The hMPXV trees can be found here <https://hgdownload.gi.ucsc.edu/hubs/GCF/014/621/545/GCF_014621545.1/UShER_hMPXV/>`_.
 
 RSV
 ---
 Respiratory Syncytial Virus (RSV) is divided into two types. Global trees developed using INDSDC samples for both RSV-A and RSV-B are available.
-* `RSV-A <https://hgdownload.gi.ucsc.edu/hubs/GCF/002/815/475/GCF_002815475.1/UShER_RSV-A/>`_
-* `RSV-B <https://hgdownload.gi.ucsc.edu/hubs/GCF/000/855/545/GCF_000855545.1/UShER_RSV-B/>`_
+
+* `RSV-A <https://hgdownload.gi.ucsc.edu/hubs/GCF/002/815/475/GCF_002815475.1/UShER_RSV-A/>`_  
+* `RSV-B <https://hgdownload.gi.ucsc.edu/hubs/GCF/000/855/545/GCF_000855545.1/UShER_RSV-B/>`_  
 
 Dengue
 ------
 The mosquito-borne dengue virus has four strain subtrees.
+
 * DENV-1
 * DENV-2
 * DENV-3

--- a/docs/source/global_trees.rst
+++ b/docs/source/global_trees.rst
@@ -2,20 +2,24 @@
 Global UShER trees
 =====================
 
-SARS-CoV-2
-----------
-SARS-CoV-2 is the virus that causes COVID-19. The global SARS-CoV-2 tree includes sequences from a variety of sources. A full list of sources and information about the trees can be found in the download's parent directory: https://hgdownload.gi.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2/
+SARS-CoV-2 (Covid-19)
+---------------------
+SARS-CoV-2 is the virus that causes COVID-19. The global SARS-CoV-2 tree includes sequences from a variety of sources. `The SARS-CoV-2 trees and information about their data sources can be found here <https://hgdownload.gi.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2/>`_.
 
-MPXV
-----
-Mpox, `previously known as monkeypox <https://www.who.int/news/item/28-11-2022-who-recommends-new-name-for-monkeypox-disease>`__, made news due to an outbreak in 2022. However, the disease is older than that, and the global MPXV tree includes INSDC samples dating back to 2016, with a focus on hMPXV (human mpox). Trees are available here: https://hgdownload.gi.ucsc.edu/hubs/GCF/014/621/545/GCF_014621545.1/UShER_hMPXV/
+hMPXV (Mpox)
+------------
+Mpox, `previously known as monkeypox <https://www.who.int/news/item/28-11-2022-who-recommends-new-name-for-monkeypox-disease>`_, made news due to an outbreak in 2022. However, the disease is older than that, and the global MPXV tree includes INSDC hMPXV (human mpox virus) samples dating back to 2016 `The hMPXV trees can be found here <https://hgdownload.gi.ucsc.edu/hubs/GCF/014/621/545/GCF_014621545.1/UShER_hMPXV/>`_.
 
 RSV
 ---
 Respiratory Syncytial Virus (RSV) is divided into two types. Global trees developed using INDSDC samples for both RSV-A and RSV-B are available.
-RSV-A: https://hgdownload.gi.ucsc.edu/hubs/GCF/002/815/475/GCF_002815475.1/UShER_RSV-A/
-RSV-B: https://hgdownload.gi.ucsc.edu/hubs/GCF/000/855/545/GCF_000855545.1/UShER_RSV-B/
+* `RSV-A <https://hgdownload.gi.ucsc.edu/hubs/GCF/002/815/475/GCF_002815475.1/UShER_RSV-A/>`_
+* `RSV-B <https://hgdownload.gi.ucsc.edu/hubs/GCF/000/855/545/GCF_000855545.1/UShER_RSV-B/>`_
 
 Dengue
 ------
-The mosquito-borne dengue virus has four strain subtrees. 
+The mosquito-borne dengue virus has four strain subtrees.
+* DENV-1
+* DENV-2
+* DENV-3
+* DENV-4

--- a/docs/source/global_trees.rst
+++ b/docs/source/global_trees.rst
@@ -1,0 +1,21 @@
+=====================
+Global UShER trees
+=====================
+
+SARS-CoV-2
+----------
+SARS-CoV-2 is the virus that causes COVID-19. The global SARS-CoV-2 tree includes sequences from a variety of sources. A full list of sources and information about the trees can be found in the download's parent directory: https://hgdownload.gi.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2/
+
+MPXV
+----
+Mpox, `previously known as monkeypox <https://www.who.int/news/item/28-11-2022-who-recommends-new-name-for-monkeypox-disease>`__, made news due to an outbreak in 2022. However, the disease is older than that, and the global MPXV tree includes INSDC samples dating back to 2016, with a focus on hMPXV (human mpox). Trees are available here: https://hgdownload.gi.ucsc.edu/hubs/GCF/014/621/545/GCF_014621545.1/UShER_hMPXV/
+
+RSV
+---
+Respiratory Syncytial Virus (RSV) is divided into two types. Global trees developed using INDSDC samples for both RSV-A and RSV-B are available.
+RSV-A: https://hgdownload.gi.ucsc.edu/hubs/GCF/002/815/475/GCF_002815475.1/UShER_RSV-A/
+RSV-B: https://hgdownload.gi.ucsc.edu/hubs/GCF/000/855/545/GCF_000855545.1/UShER_RSV-B/
+
+Dengue
+------
+The mosquito-borne dengue virus has four strain subtrees. 

--- a/docs/source/global_trees.rst
+++ b/docs/source/global_trees.rst
@@ -1,25 +1,27 @@
 =====================
 Global UShER trees
 =====================
+UCSC provides downloadable tree and metadata files for daily-updated trees of genetic sequences for the following pathogens.
+
 
 SARS-CoV-2 (Covid-19)
 ---------------------
-SARS-CoV-2 is the virus that causes COVID-19. The global SARS-CoV-2 tree includes sequences from a variety of sources. `The SARS-CoV-2 trees and information about their data sources can be found here <https://hgdownload.gi.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2/>`_.
+SARS-CoV-2 is the virus that causes COVID-19. The global SARS-CoV-2 tree includes sequences from a variety of sources, including but not limited to INSDC (GenBank/ENA/DDBJ). `The SARS-CoV-2 trees and information about their data sources can be found here <https://hgdownload.gi.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2/>`_.
 
 hMPXV (Mpox)
 ------------
-Mpox, `previously known as monkeypox <https://www.who.int/news/item/28-11-2022-who-recommends-new-name-for-monkeypox-disease>`_, made news due to an outbreak in 2022. However, the disease is older than that, and the global MPXV tree includes INSDC hMPXV (human mpox virus) samples dating back to 2016. `The hMPXV trees can be found here <https://hgdownload.gi.ucsc.edu/hubs/GCF/014/621/545/GCF_014621545.1/UShER_hMPXV/>`_.
+Mpox, `previously known as monkeypox <https://www.who.int/news/item/28-11-2022-who-recommends-new-name-for-monkeypox-disease>`_, made news due to an outbreak in 2022. However, the disease is older than that, and the global MPXV tree includes INSDC samples from 2017 and later. The term "hMPXV" is used to reflect that these recent samples show sustained human-to-human transmission (clade IIb from the `Happi et al. nomenclature <https://journals.plos.org/plosbiology/article?id=10.1371/journal.pbio.3001769>`_). The hMPXV trees can be found `here <https://hgdownload.gi.ucsc.edu/hubs/GCF/014/621/545/GCF_014621545.1/UShER_hMPXV/>`__.
 
 RSV
 ---
-Respiratory Syncytial Virus (RSV) is divided into two types. Global trees developed using INDSDC samples for both RSV-A and RSV-B are available.
+Respiratory Syncytial Virus (RSV) is divided into two antigenic types. Global trees developed using INDSDC samples for both RSV-A and RSV-B are available.
 
 * `RSV-A <https://hgdownload.gi.ucsc.edu/hubs/GCF/002/815/475/GCF_002815475.1/UShER_RSV-A/>`_  
 * `RSV-B <https://hgdownload.gi.ucsc.edu/hubs/GCF/000/855/545/GCF_000855545.1/UShER_RSV-B/>`_  
 
 Dengue
 ------
-The mosquito-borne dengue virus has four strain subtrees.
+The mosquito-borne dengue virus has four serotypes. UCSC maintains trees for each serotype based on INDSDC samples.
 
 * DENV-1
 * DENV-2

--- a/docs/source/global_trees.rst
+++ b/docs/source/global_trees.rst
@@ -1,16 +1,29 @@
 =====================
 Global UShER trees
 =====================
-UCSC provides downloadable tree and metadata files for daily-updated trees of genetic sequences for the following pathogens.
+UCSC provides downloadable tree and metadata files for trees of genetic sequences for the following pathogens.
 
 
 SARS-CoV-2 (Covid-19)
 ---------------------
-SARS-CoV-2 is the virus that causes COVID-19. The global SARS-CoV-2 tree includes sequences from a variety of sources, including but not limited to INSDC (GenBank/ENA/DDBJ). `The SARS-CoV-2 trees and information about their data sources can be found here <https://hgdownload.gi.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2/>`_.
+SARS-CoV-2 is the virus that causes COVID-19. The global SARS-CoV-2 tree includes sequences from a variety of sources, including but not limited to INSDC (GenBank/ENA/DDBJ). The SARS-CoV-2 trees and information about their data sources `can be found here <https://hgdownload.gi.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2/>`_. You can also `click here to view the latest tree in taxonium <https://taxonium.org/sars-cov-2/public>`_. 
 
 hMPXV (Mpox)
 ------------
-Mpox, `previously known as monkeypox <https://www.who.int/news/item/28-11-2022-who-recommends-new-name-for-monkeypox-disease>`_, made news due to an outbreak in 2022. However, the disease is older than that, and the global MPXV tree includes INSDC samples from 2017 and later. The term "hMPXV" is used to reflect that these recent samples show sustained human-to-human transmission (clade IIb from the `Happi et al. nomenclature <https://journals.plos.org/plosbiology/article?id=10.1371/journal.pbio.3001769>`_). The hMPXV trees can be found `here <https://hgdownload.gi.ucsc.edu/hubs/GCF/014/621/545/GCF_014621545.1/UShER_hMPXV/>`__.
+Mpox, `previously known as monkeypox <https://www.who.int/news/item/28-11-2022-who-recommends-new-name-for-monkeypox-disease>`_, made news due to an outbreak in 2022. However, the disease is older than that, and the global MPXV tree includes INSDC samples from 2017 and later. 
+
+The term "hMPXV" is used to reflect that these recent samples show sustained human-to-human transmission (clade IIb from the `Happi et al. nomenclature <https://journals.plos.org/plosbiology/article?id=10.1371/journal.pbio.3001769>`_). The hMPXV trees can be found `here <https://hgdownload.gi.ucsc.edu/hubs/GCF/000/857/045/GCF_000857045.1/UShER_MPXV_cladeI/>`_.`here <https://hgdownload.gi.ucsc.edu/hubs/GCF/014/621/545/GCF_014621545.1/UShER_hMPXV/>`__. 
+
+We also have a tree of clade 1 which can be found `here <https://hgdownload.gi.ucsc.edu/hubs/GCF/000/857/045/GCF_000857045.1/UShER_MPXV_cladeI/>`_.
+
+Influenza
+---------
+Trees for a variety of influenza A strains can be found `here <https://hgdownload.gi.ucsc.edu/hubs/GCF/000/864/105/GCF_000864105.1/>_. 
+
+For most of our Influenza A assemblies we use a RefSeq assembly as reference and root. There are two exceptions, representing recent outbreaks:
+
+* `H5N1 D1.1 2024 outbreak <https://hgdownload.gi.ucsc.edu/hubs/GCF/000/864/105/GCF_000864105.1/UShER_h5n1_D1.1_2024/>_`, which is rooted to a concatenation of Genbank segement sequences PQ844107.1, OP597633.1, PQ885594.1, LC718226.1, PQ585621.1, PQ664459.1, OP597621.1, and PQ712157.1
+* `H5N1 B3.13 cattle 2024 outbreak <https://hgdownload.gi.ucsc.edu/hubs/GCF/000/864/105/GCF_000864105.1/UShER_h5n1_outbreak_2024/>`, which is rooted to a concatenation of Genbank segement sequences PP755620.1, PP755619.1, PP755618.1, PP753693.1, PP755616.1, PP753695.1, PP755614.1, and PP753097.1
 
 RSV
 ---
@@ -19,11 +32,16 @@ Respiratory Syncytial Virus (RSV) is divided into two antigenic types. Global tr
 * `RSV-A <https://hgdownload.gi.ucsc.edu/hubs/GCF/002/815/475/GCF_002815475.1/UShER_RSV-A/>`_  
 * `RSV-B <https://hgdownload.gi.ucsc.edu/hubs/GCF/000/855/545/GCF_000855545.1/UShER_RSV-B/>`_  
 
+You can also place samples on a tree with a reconstructed root `here <https://genome.ucsc.edu/cgi-bin/hgPhyloPlace?hgpp_org=rsv_rgcc>`_.
+
 Dengue
 ------
 The mosquito-borne dengue virus has four serotypes. UCSC maintains trees for each serotype based on INDSDC samples.
 
-* DENV-1
-* DENV-2
-* DENV-3
-* DENV-4
+* `DENV-1 <https://hgdownload.gi.ucsc.edu/hubs/GCF/000/862/125/GCF_000862125.1/UShER_DENV-1/>`_, based on NC_001477.1
+* `DENV-2 <https://hgdownload.gi.ucsc.edu/hubs/GCF/000/871/845/GCF_000871845.1/UShER_DENV-2/>`_, based on NC_001474.2
+* `DENV-3 <https://hgdownload.gi.ucsc.edu/hubs/GCF/000/866/625/GCF_000866625.1/UShER_DENV-3/>`_, based on NC_001475.2
+* `DENV-4 <https://hgdownload.gi.ucsc.edu/hubs/GCF/000/865/065/GCF_000865065.1/UShER_DENV-4/>`_, based on NC_002640.1
+
+
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -2,7 +2,7 @@
 UShER Wiki
 ***************
 
-Welcome to the manual for UShER package, that includes SARS-CoV-2 Phylogenetics tools UShER, matUtils, matOptimize, RIPPLES, strain_phylogenetics, and others. Please see the table of contents on the sidebar, or :doc:`click here <QuickStart>` for a quick tutorial on getting started.
+Welcome to the manual for UShER package, that includes SARS-CoV-2 Phylogenetics tools UShER, matUtils, matOptimize, RIPPLES, strain_phylogenetics, and others. Please see the table of contents on the sidebar, or :doc:`click here <QuickStart>` for a quick tutorial on getting started. If you are interested in global trees for SARS-COV-2 or other pathogens, :doc:`click here <global_trees>`.
 
 .. toctree::
    :hidden:
@@ -17,6 +17,7 @@ Welcome to the manual for UShER package, that includes SARS-CoV-2 Phylogenetics 
    Strain_Phylogenetics
    tutorials
    presentations/presentations
+   global_trees
 
 .. _UShER:
 


### PR DESCRIPTION
This needs some updates before merging...

Feedback sought:
* Ordering of pathogens? Alphabetical makes more sense but maybe we want covid at the top?
* Viral usher?
* Better explanation for influenza A? / Restate what's on hgPyloPlace for some/all pathogens?
* Maybe each section should be formatted as 1) few sentences on the pathogen 2) bullet point taxonium link 3) [bullet point USHER web interface link ](https://genome.ucsc.edu/cgi-bin/hgPhyloPlace) 4) bullet link to hgstorage?

Ash todo: The TB tree on hgPhyloPlace has a different datestamp than the one on taxonium, confirm with Lily. Also include link to version with and without M. canettii if possible.